### PR TITLE
Remove and re-add Nerdbank.GitVersioning references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
-    </ItemGroup>
+    <!--<ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="All" />
+    </ItemGroup>-->
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
         <PackageVersion Include="Identity.Module.Licenses" Version="1.0.44" />
         <PackageVersion Include="Identity.Module.PolicyManager" Version="1.0.50" />
         <!--<PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="All" />-->
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
         <PackageVersion Include="MailKit" Version="4.13.0" />
         <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
         <PackageVersion Include="Scrutor" Version="6.1.0" />

--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Nerdbank.GitVersioning" />
 </ItemGroup>
 
 <ItemGroup>


### PR DESCRIPTION
Updated project references for Nerdbank.GitVersioning:
- Removed the `PackageReference` from `Directory.Build.props`.
- Uncommented the `PackageVersion` in `Directory.Packages.props`.
- Added a new `PackageReference` in `MinimalApi.Identity.API.csproj`.