### PR TITLE
Add EF Core packages and dependency injection abstraction

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Identity.Module.Core" Version="2.5.6" />
     <PackageVersion Include="Identity.Module.Licenses" Version="1.0.44" />
     <PackageVersion Include="Identity.Module.PolicyManager" Version="1.0.50" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="All" />
     <PackageVersion Include="MailKit" Version="4.13.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />

--- a/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
+++ b/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
@@ -28,6 +28,8 @@
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Added `Microsoft.Extensions.DependencyInjection.Abstractions` (v8.0.2) to `Directory.Packages.props`.
- Included `Microsoft.EntityFrameworkCore` and `Microsoft.EntityFrameworkCore.SqlServer` in `MinimalApi.Identity.Core.csproj`.