### PR TITLE
Develop

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Identity.Module.API" Version="2.5.13" />
-    <PackageVersion Include="Identity.Module.Core" Version="2.5.11" />
+    <PackageVersion Include="Identity.Module.Core" Version="2.5.18" />
     <PackageVersion Include="Identity.Module.Licenses" Version="1.0.44" />
     <PackageVersion Include="Identity.Module.PolicyManager" Version="2.5.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />

--- a/src/MinimalApi.Identity.Core/Database/Configurations/ClaimTypeConfiguration.cs
+++ b/src/MinimalApi.Identity.Core/Database/Configurations/ClaimTypeConfiguration.cs
@@ -9,132 +9,150 @@ public class ClaimTypeConfiguration : IEntityTypeConfiguration<ClaimType>
 {
     public void Configure(EntityTypeBuilder<ClaimType> builder)
     {
-        builder.HasData(new ClaimType
-        {
-            Id = 1,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.AuthPolicy),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 2,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.AuthPolicyRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 3,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.AuthPolicyWrite),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 4,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.Claim),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 5,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ClaimRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 6,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ClaimWrite),
-            Default = true
-        },
+        var claimTypeList = new List<ClaimType>();
+        var idRiga = 0;
 
-        new ClaimType
+        foreach (var ct in Enum.GetValues<ClaimsType>())
         {
-            Id = 7,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.Licenza),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 8,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.LicenzaRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 9,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.LicenzaWrite),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 10,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.Modulo),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 11,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ModuloRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 12,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ModuloWrite),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 13,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.Profilo),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 14,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ProfiloRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 15,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.ProfiloWrite),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 16,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.Ruolo),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 17,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.RuoloRead),
-            Default = true
-        },
-        new ClaimType
-        {
-            Id = 18,
-            Type = nameof(ClaimsType.Permission),
-            Value = nameof(Permissions.RuoloWrite),
-            Default = true
-        });
+            claimTypeList.Add(new ClaimType
+            {
+                Id = idRiga,
+                Type = nameof(ClaimsType.Permission),
+                Value = ct.ToString(),
+                Default = true
+            });
+
+            idRiga++;
+        }
+
+        builder.HasData(claimTypeList);
+
+        //builder.HasData(new ClaimType
+        //{
+        //    Id = 1,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.AuthPolicy),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 2,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.AuthPolicyRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 3,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.AuthPolicyWrite),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 4,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.Claim),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 5,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ClaimRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 6,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ClaimWrite),
+        //    Default = true
+        //},
+
+        //new ClaimType
+        //{
+        //    Id = 7,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.Licenza),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 8,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.LicenzaRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 9,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.LicenzaWrite),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 10,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.Modulo),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 11,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ModuloRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 12,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ModuloWrite),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 13,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.Profilo),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 14,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ProfiloRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 15,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.ProfiloWrite),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 16,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.Ruolo),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 17,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.RuoloRead),
+        //    Default = true
+        //},
+        //new ClaimType
+        //{
+        //    Id = 18,
+        //    Type = nameof(ClaimsType.Permission),
+        //    Value = nameof(Permissions.RuoloWrite),
+        //    Default = true
+        //});
     }
 }

--- a/src/MinimalApi.Identity.Core/Database/Configurations/EmailSendingConfiguration.cs
+++ b/src/MinimalApi.Identity.Core/Database/Configurations/EmailSendingConfiguration.cs
@@ -8,6 +8,16 @@ public class EmailSendingConfiguration : IEntityTypeConfiguration<EmailSending>
 {
     public void Configure(EntityTypeBuilder<EmailSending> builder)
     {
-        builder.Property(x => x.EmailSendingType).HasConversion<string>();
+        //builder.Property(x => x.EmailSendingType).HasConversion<string>();
+
+        builder.HasOne(builder => builder.TypeEmailSending)
+            .WithMany(y => y.EmailSendings)
+            .HasForeignKey(y => y.TypeEmailSendingId)
+            .IsRequired();
+
+        builder.HasOne(builder => builder.TypeEmailStatus)
+            .WithMany(typeEmailStatus => typeEmailStatus.EmailSendings)
+            .HasForeignKey(builder => builder.TypeEmailStatusId)
+            .IsRequired();
     }
 }

--- a/src/MinimalApi.Identity.Core/Database/Configurations/TypeEmailSendingConfiguration.cs
+++ b/src/MinimalApi.Identity.Core/Database/Configurations/TypeEmailSendingConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MinimalApi.Identity.Core.Entities;
+
+namespace MinimalApi.Identity.Core.Database.Configurations;
+
+public class TypeEmailSendingConfiguration : IEntityTypeConfiguration<TypeEmailSending>
+{
+    public void Configure(EntityTypeBuilder<TypeEmailSending> builder)
+    {
+        builder.HasData(
+            new TypeEmailSending
+            {
+                Id = 1,
+                Name = "RegisterUser",
+                Description = "Email sent during user registration"
+            },
+            new TypeEmailSending
+            {
+                Id = 2,
+                Name = "ChangeEmail",
+                Description = "Email sent for changing email address"
+            },
+            new TypeEmailSending
+            {
+                Id = 3,
+                Name = "ForgotPassword",
+                Description = "Email sent for password reset requests"
+            }
+        );
+    }
+}

--- a/src/MinimalApi.Identity.Core/Database/Configurations/TypeEmailStatusConfiguration.cs
+++ b/src/MinimalApi.Identity.Core/Database/Configurations/TypeEmailStatusConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MinimalApi.Identity.Core.Entities;
+
+namespace MinimalApi.Identity.Core.Database.Configurations;
+
+public class TypeEmailStatusConfiguration : IEntityTypeConfiguration<TypeEmailStatus>
+{
+    public void Configure(EntityTypeBuilder<TypeEmailStatus> builder)
+    {
+        builder.HasData(
+            new TypeEmailStatus
+            {
+                Id = 1,
+                Name = "Sent",
+                Description = "Email has been sent successfully"
+            },
+            new TypeEmailStatus
+            {
+                Id = 2,
+                Name = "Pending",
+                Description = "Email is pending to be sent"
+            },
+            new TypeEmailStatus
+            {
+                Id = 3,
+                Name = "Failed",
+                Description = "Email sending failed"
+            },
+            new TypeEmailStatus
+            {
+                Id = 4,
+                Name = "Cancelled",
+                Description = "Email sending has been cancelled"
+            }
+        );
+    }
+}

--- a/src/MinimalApi.Identity.Core/Entities/EmailSending.cs
+++ b/src/MinimalApi.Identity.Core/Entities/EmailSending.cs
@@ -1,16 +1,25 @@
 ﻿using MinimalApi.Identity.Core.Entities.Common;
-using MinimalApi.Identity.Core.Enums;
 
 namespace MinimalApi.Identity.Core.Entities;
 
 public class EmailSending : BaseEntity, IEntity
 {
-    public EmailSendingType EmailSendingType { get; set; }
     public string EmailTo { get; set; } = null!;
     public string Subject { get; set; } = null!;
     public string Body { get; set; } = null!;
-    public bool Sent { get; set; }
-    public DateTime DateSent { get; set; }
-    public string? ErrorMessage { get; set; } //Consente valore NULL
-    public string? ErrorDetails { get; set; } //Consente valore NULL
+    //public int EmailSendingStatusId { get; set; }
+    //public EmailSendingStatus EmailSendingStatus { get; set; } = null!;
+    //public int EmailSendingId { get; set; }
+    //public EmailSending EmailSending { get; set; } = null!;
+    public int TypeEmailSendingId { get; set; }
+    public TypeEmailSending TypeEmailSending { get; set; } = null!;
+    //public bool Sent { get; set; }
+    public int TypeEmailStatusId { get; set; }
+    public TypeEmailStatus TypeEmailStatus { get; set; } = null!;
+    public DateTime DateSent { get; set; } // Data e ora in cui l'email è stata inviata con successo
+    public int RetrySender { get; set; } // Numero di tentativi di invio dell'email - Numero tentativi: 10 (default)
+    //public TimeSpan DelayOnError { get; set; } // Tempo di attesa tra i tentativi di invio dell'email in caso di errore - Default: 00:00:30 (30 secondi)
+    public DateTime? RetrySenderDate { get; set; } // Data e ora dell'ultimo tentativo di invio dell'email
+    public string? RetrySenderErrorMessage { get; set; } //Consente valore NULL
+    public string? RetrySenderErrorDetails { get; set; } //Consente valore NULL
 }

--- a/src/MinimalApi.Identity.Core/Entities/TypeEmailSending.cs
+++ b/src/MinimalApi.Identity.Core/Entities/TypeEmailSending.cs
@@ -1,0 +1,10 @@
+﻿using MinimalApi.Identity.Core.Entities.Common;
+
+namespace MinimalApi.Identity.Core.Entities;
+
+public class TypeEmailSending : BaseEntity, IEntity
+{
+    public string Name { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public ICollection<EmailSending> EmailSendings { get; set; } = [];
+}

--- a/src/MinimalApi.Identity.Core/Entities/TypeEmailStatus.cs
+++ b/src/MinimalApi.Identity.Core/Entities/TypeEmailStatus.cs
@@ -1,0 +1,10 @@
+﻿using MinimalApi.Identity.Core.Entities.Common;
+
+namespace MinimalApi.Identity.Core.Entities;
+
+public class TypeEmailStatus : BaseEntity, IEntity
+{
+    public string Name { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public ICollection<EmailSending> EmailSendings { get; set; } = [];
+}

--- a/src/MinimalApi.Identity.Core/Enums/EmailSendingType.cs
+++ b/src/MinimalApi.Identity.Core/Enums/EmailSendingType.cs
@@ -2,7 +2,7 @@
 
 public enum EmailSendingType
 {
-    RegisterUser,
-    ChangeEmail,
-    ForgotPassword
+    RegisterUser = 1,
+    ChangeEmail = 2,
+    ForgotPassword = 3
 }

--- a/src/MinimalApi.Identity.Core/Enums/EmailStatusType.cs
+++ b/src/MinimalApi.Identity.Core/Enums/EmailStatusType.cs
@@ -1,0 +1,9 @@
+﻿namespace MinimalApi.Identity.Core.Enums;
+
+public enum EmailStatusType
+{
+    Sent = 1, // Indica che l'email è stata inviata con successo
+    Pending = 2, // Indica che l'email è in attesa di essere inviata
+    Failed = 3, // Indica che l'invio dell'email è fallito ma i tentativi non sono finiti
+    Cancelled = 4 // Indica che l'invio dell'email è stato annullato causa superamento del numero di tentativi
+}

--- a/src/MinimalApi.Identity.Core/Exceptions/BadRequestException.cs
+++ b/src/MinimalApi.Identity.Core/Exceptions/BadRequestException.cs
@@ -16,16 +16,4 @@ public class BadRequestException : Exception
 
     public BadRequestException(IEnumerable<IdentityError> errors) : base(GenericExtensions.FormatErrorMessage(errors))
     { }
-
-    //private static string FormatErrorMessage(IEnumerable<IdentityError> errors)
-    //{
-    //    var sb = new StringBuilder();
-
-    //    foreach (var error in errors)
-    //    {
-    //        sb.AppendLine($"{error.Code}: {error.Description}");
-    //    }
-
-    //    return sb.ToString();
-    //}
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the email sending domain in the identity module, focusing on refactoring the way email types and statuses are represented and managed. The changes include replacing enum-based configurations with entity-based tables for email types and statuses, updating the `EmailSending` entity to use these new relationships, and seeding initial data for both types and statuses. Additionally, there is a minor update to the claims type configuration and a package version bump.

### Email Sending Domain Refactor

* Introduced new entities `TypeEmailSending` and `TypeEmailStatus`, each with their own configuration and seeded initial data, to replace previous enum usage for email types and statuses (`TypeEmailSending.cs`, `TypeEmailStatus.cs`, `TypeEmailSendingConfiguration.cs`, `TypeEmailStatusConfiguration.cs`). [[1]](diffhunk://#diff-d4743fb104c4414f661dac2016b89f4ec7b0064b3c56490f9d3e5d0a33e23f9bR1-R10) [[2]](diffhunk://#diff-3b6343af30e5dd613dba22326e1a261ba089ad81ecb88bdb3da7e77d9555c633R1-R10) [[3]](diffhunk://#diff-3140edb6f4d6a0fb4a72526c2ae87b89e824521ff1f81107676628200730d69eR1-R32) [[4]](diffhunk://#diff-f3e943c0be7a97ab69e3a29b5fd4ef5898b96cbea4fb8648252ab35b029688a5R1-R38)
* Refactored the `EmailSending` entity to use foreign keys and navigation properties for `TypeEmailSending` and `TypeEmailStatus`, and added fields for retry logic and error details (`EmailSending.cs`).
* Updated the `EmailSendingConfiguration` to establish relationships with the new type/status entities and removed the previous enum conversion (`EmailSendingConfiguration.cs`).

### Enum and Data Seeding Updates

* Added a new enum `EmailStatusType` for code reference, and updated `EmailSendingType` to use explicit integer values (`EmailStatusType.cs`, `EmailSendingType.cs`). [[1]](diffhunk://#diff-923b6694c5706d0bbdf5ae19ea1a25ec608bda6a2f9166389e16f7915ab40fc8R1-R9) [[2]](diffhunk://#diff-5e19c7fec2d861e5561b37905e5a8805c06ef61758a55ec0214b39903cee9187L5-R7)
* Refactored claim type seeding to dynamically generate data from the `ClaimsType` enum instead of hardcoding values (`ClaimTypeConfiguration.cs`).

### Dependency Update

* Upgraded the `Identity.Module.Core` package version from `2.5.11` to `2.5.18` (`Directory.Packages.props`).