### PR TITLE
Add SmtpOptions class for email configuration

### DIFF
--- a/src/MinimalApi.Identity.Core/Options/SmtpOptions.cs
+++ b/src/MinimalApi.Identity.Core/Options/SmtpOptions.cs
@@ -1,0 +1,29 @@
+﻿using MailKit.Security;
+
+namespace MinimalApi.Identity.Core.Options;
+
+public class SmtpOptions
+{
+    //[Required]
+    public string Host { get; init; } = null!;
+
+    //[IntegerInList(25, 587, 465, ErrorMessage = "Port must be one of the following: 25, 587, 465.")]
+    public int Port { get; init; }
+
+    //[Required]
+    public SecureSocketOptions Security { get; init; }
+
+    //[Required]
+    public string Username { get; init; } = null!;
+
+    //[Required]
+    public string Password { get; init; } = null!;
+
+    //[Required]
+    //[EmailAddress(ErrorMessage = "Sender must be a valid email address.")]
+    public string Sender { get; init; } = null!;
+
+    //public bool SaveEmailSent { get; init; }
+    public int MaxRetryAttempts { get; init; } = 10; // Default: 10 attempts
+    public TimeSpan RetryDelay { get; init; } = TimeSpan.FromSeconds(30); // Default: 30 seconds delay between retries
+}


### PR DESCRIPTION
Introduces the `SmtpOptions` class in the `MinimalApi.Identity.Core.Options` namespace. This class includes properties for SMTP settings such as `Host`, `Port`, `Security`, `Username`, `Password`, and `Sender`, with default values or non-nullable types. It also features `MaxRetryAttempts` and `RetryDelay` for handling email sending retries. Commented-out validation attributes indicate potential future enhancements.