### PR TITLE
Develop

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,9 +5,9 @@ on:
       branches-ignore: [ main ]
       # Remove the line above to run when pushing to main  
       paths: [ 'src/**' ]
-    pull_request:   
-      branches: [ main, develop ]
-      paths: [ 'src/**' ]    
+#    pull_request:   
+#      branches: [ main, develop ]
+#      paths: [ 'src/**' ]    
     workflow_dispatch:
     
 jobs:

--- a/.github/workflows/publish_account_manager.yml
+++ b/.github/workflows/publish_account_manager.yml
@@ -1,0 +1,54 @@
+name: Publish Identity.Module.AccountManager on NuGet
+ 
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'src/MinimalApi.Identity.AccountManager/**' ]
+  workflow_dispatch:
+      
+env:
+  NET_VERSION: '8.x'
+  PROJECT_NAME: src/MinimalApi.Identity.AccountManager
+  PROJECT_FILE: MinimalApi.Identity.AccountManager.csproj
+  TAG_NAME: Identity.Module.AccountManager
+  RELEASE_NAME: Identity.Module.AccountManager
+  
+jobs:
+  build:
+    name: Publish on NuGet
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4.2.2
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+    - name: Setup .NET Core SDK ${{ env.NET_VERSION }}
+      uses: actions/setup-dotnet@v4.3.0
+      with:
+        dotnet-version: ${{ env.NET_VERSION }}
+        dotnet-quality: 'ga'
+
+    - name: Nerdbank.GitVersioning 
+      uses: dotnet/nbgv@v0.4.2
+      id: nbgv
+      with:        
+        path: ${{ env.PROJECT_NAME }}
+
+    - name: Package
+      run: dotnet pack -c Release -o . '${{ env.PROJECT_NAME }}/${{ env.PROJECT_FILE }}'
+
+    - name: Publish on NuGet
+      run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --no-symbols --skip-duplicate
+      
+    - name: Create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          tag_name: ${{ env.TAG_NAME }}_v${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          release_name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          body: Integration package, requires the Identity.Module.API package to work.
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish_results.yml
+++ b/.github/workflows/publish_results.yml
@@ -1,0 +1,54 @@
+name: Publish Identity.Module.Results on NuGet
+  
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'src/MinimalApi.Identity.Results/**' ]
+  workflow_dispatch:
+      
+env:
+  NET_VERSION: '8.x'
+  PROJECT_NAME: src/MinimalApi.Identity.Results
+  PROJECT_FILE: MinimalApi.Identity.Results.csproj
+  TAG_NAME: Identity.Module.Results
+  RELEASE_NAME: Identity.Module.Results
+  
+jobs:
+  build:
+    name: Publish on NuGet
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4.2.2
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+    - name: Setup .NET Core SDK ${{ env.NET_VERSION }}
+      uses: actions/setup-dotnet@v4.3.0
+      with:
+        dotnet-version: ${{ env.NET_VERSION }}
+        dotnet-quality: 'ga'
+
+    - name: Nerdbank.GitVersioning 
+      uses: dotnet/nbgv@v0.4.2
+      id: nbgv
+      with:        
+        path: ${{ env.PROJECT_NAME }}
+
+    - name: Package
+      run: dotnet pack -c Release -o . '${{ env.PROJECT_NAME }}/${{ env.PROJECT_FILE }}'
+
+    - name: Publish on NuGet
+      run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --no-symbols --skip-duplicate
+      
+    - name: Create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          tag_name: ${{ env.TAG_NAME }}_v${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          release_name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          body: Integration package, requires the Identity.Module.API package to work.
+          draft: false
+          prerelease: false

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Identity.Module.EmailManager" Version="2.5.13" />
     <PackageVersion Include="Identity.Module.Licenses" Version="1.0.44" />
     <PackageVersion Include="Identity.Module.PolicyManager" Version="2.5.23" />
+    <PackageVersion Include="Identity.Module.ProfileManager" Version="2.5.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="All" />
     <PackageVersion Include="MailKit" Version="4.13.0" />

--- a/src/MinimalApi.Identity.ProfileManager/DependencyInjection/ProfileExtensions.cs
+++ b/src/MinimalApi.Identity.ProfileManager/DependencyInjection/ProfileExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinimalApi.Identity.Core.DependencyInjection;
+using MinimalApi.Identity.Core.Enums;
+using MinimalApi.Identity.ProfileManager.Services;
+using MinimalApi.Identity.ProfileManager.Validator;
+
+namespace MinimalApi.Identity.ProfileManager.DependencyInjection;
+
+public static class ProfileExtensions
+{
+    public const string FullName = nameof(ClaimsType.FullName);
+
+    public const string EndpointsGetProfile = "/{userId}";
+    public const string EndpointsEditProfile = "/edit-profile";
+    public const string EndpointsChangeEnableProfile = "/change-enable-profile";
+
+    public static IServiceCollection ProfileManagerRegistrationService(this IServiceCollection services)
+    {
+        services
+            .AddRegisterServices(options =>
+            {
+                options.Interfaces = [typeof(IProfileService)];
+                options.StringEndsWith = "Service";
+                options.Lifetime = ServiceLifetime.Transient;
+            })
+            .ConfigureFluentValidation<CreateUserProfileValidator>();
+
+        return services;
+    }
+}

--- a/src/MinimalApi.Identity.ProfileManager/DependencyInjection/ProfileQuery.cs
+++ b/src/MinimalApi.Identity.ProfileManager/DependencyInjection/ProfileQuery.cs
@@ -1,0 +1,112 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using MinimalApi.Identity.API.Mapping;
+using MinimalApi.Identity.Core.Database;
+using MinimalApi.Identity.Core.Entities;
+using MinimalApi.Identity.Core.Exceptions;
+using MinimalApi.Identity.Core.Utility.Messages;
+using MinimalApi.Identity.ProfileManager.Models;
+
+namespace MinimalApi.Identity.ProfileManager.DependencyInjection;
+
+public static class ProfileQuery
+{
+    public static async Task<List<UserProfileModel>> GetAllProfilesAsync(MinimalApiAuthDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var profiles = await dbContext.Set<UserProfile>()
+            .AsNoTracking()
+            .Select(profile => ProfileMapper.ToEntity(profile))
+            .ToListAsync(cancellationToken);
+
+        return profiles.Count == 0 ? throw new NotFoundException(MessagesApi.ProfilesNotFound) : profiles;
+    }
+
+    public static async Task<UserProfileModel> GetProfileAsync(int userId, MinimalApiAuthDbContext dbContext, UserManager<ApplicationUser> userManager, CancellationToken cancellationToken)
+    {
+        var user = await userManager.FindByIdAsync(userId.ToString()) ?? throw new NotFoundException(MessagesApi.ProfileNotFound);
+
+        var profile = await dbContext.Set<UserProfile>()
+            .AsNoTracking()
+            .Where(x => x.UserId == user.Id)
+            .FirstOrDefaultAsync(cancellationToken) ?? throw new NotFoundException(MessagesApi.ProfileNotFound);
+
+        return ProfileMapper.ToEntity(profile);
+    }
+
+    public static async Task<string> CreateProfileAsync(CreateUserProfileModel model, MinimalApiAuthDbContext dbContext, CancellationToken cancellationToken)
+    {
+        //var profile = new UserProfile(model.UserId, model.FirstName, model.LastName);
+
+        //profile.ChangeUserEnabled(true);
+        //profile.ChangeLastDateChangePassword(DateOnly.FromDateTime(DateTime.Now));
+
+        var profile = new UserProfile
+        {
+            UserId = model.UserId,
+            FirstName = model.FirstName,
+            LastName = model.LastName,
+            IsEnabled = true,
+            LastDateChangePassword = DateOnly.FromDateTime(DateTime.UtcNow)
+        };
+
+        dbContext.Set<UserProfile>().Add(profile);
+        var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+        return result > 0 ? MessagesApi.ProfileCreated : MessagesApi.ProfileNotCreated;
+    }
+
+    public static async Task<string> EditProfileAsync(EditUserProfileModel model, MinimalApiAuthDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var profile = await dbContext.Set<UserProfile>().AsNoTracking()
+            .Where(x => x.UserId == model.UserId)
+            .FirstOrDefaultAsync(cancellationToken) ?? throw new NotFoundException(MessagesApi.ProfileNotFound);
+
+        profile.FirstName = model.FirstName;
+        profile.LastName = model.LastName;
+
+        //profile.ChangeFirstName(model.FirstName);
+        //profile.ChangeLastName(model.LastName);
+
+        dbContext.Set<UserProfile>().Update(profile);
+        var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+        return result > 0 ? MessagesApi.ProfileUpdated : throw new BadRequestException(MessagesApi.ProfileNotUpdated);
+    }
+
+    public static async Task<List<Claim>> GetClaimUserProfileAsync(ApplicationUser user, MinimalApiAuthDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var result = await dbContext.Set<UserProfile>()
+            .AsNoTracking()
+            .Where(ul => ul.UserId == user.Id)
+            .Select(ul => new { ul.FirstName, ul.LastName })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return result switch
+        {
+            null => [],
+            _ => [
+                new Claim(ClaimTypes.GivenName, result.FirstName ?? string.Empty),
+                new Claim(ClaimTypes.Surname, result.LastName ?? string.Empty),
+                new Claim(ProfileExtensions.FullName, $"{result.FirstName} {result.LastName}")
+            ]
+        };
+    }
+
+    public static async Task<string> ChangeEnablementStatusUserProfileAsync(ChangeEnableProfileModel model, MinimalApiAuthDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var profile = await dbContext.Set<UserProfile>()
+            .AsNoTracking()
+            .Where(x => x.UserId == model.UserId)
+            .FirstOrDefaultAsync(cancellationToken) ?? throw new NotFoundException(MessagesApi.ProfileNotFound);
+
+        //profile.ChangeUserEnabled(model.IsEnabled);
+        profile.IsEnabled = model.IsEnabled;
+
+        dbContext.Set<UserProfile>().Update(profile);
+        var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+        return result > 0 ? model.IsEnabled ? MessagesApi.ProfileEnabled : MessagesApi.ProfileDisabled
+            : throw new BadRequestException(model.IsEnabled ? MessagesApi.ProfileNotEnabled : MessagesApi.ProfileNotDisabled);
+    }
+}

--- a/src/MinimalApi.Identity.ProfileManager/Endpoints/ProfilesEndpoints.cs
+++ b/src/MinimalApi.Identity.ProfileManager/Endpoints/ProfilesEndpoints.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.OpenApi.Models;
+using MinimalApi.Identity.Core.DependencyInjection;
+using MinimalApi.Identity.Core.Enums;
+using MinimalApi.Identity.Core.Utility.Generators;
+using MinimalApi.Identity.ProfileManager.DependencyInjection;
+using MinimalApi.Identity.ProfileManager.Extensions;
+using MinimalApi.Identity.ProfileManager.Models;
+
+namespace MinimalApi.Identity.API.Endpoints;
+
+//public class ProfilesEndpoints : IEndpointRouteHandlerBuilder
+public static class ProfilesEndpoints
+{
+    //public static void MapEndpoints(IEndpointRouteBuilder endpoints)
+    //{
+    //    var apiGroup = endpoints
+    //        .MapGroup(EndpointGenerator.EndpointsProfilesGroup)
+    //        .RequireAuthorization()
+    //        .WithOpenApi(opt =>
+    //        {
+    //            opt.Tags = [new OpenApiTag { Name = EndpointGenerator.EndpointsProfilesTag }];
+    //            return opt;
+    //        });
+    public static IEndpointRouteBuilder MapProfileEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var apiGroup = endpoints
+            .MapGroup(EndpointGenerator.EndpointsLicenseGroup)
+            .WithOpenApi(opt =>
+            {
+                opt.Tags = [new OpenApiTag { Name = EndpointGenerator.EndpointsLicenseTag }];
+                return opt;
+            });
+
+        //apiGroup.MapGet(EndpointGenerator.EndpointsStringEmpty, async ([FromServices] IProfileService profileService) =>
+        //{
+        //    return TypedResults.Ok(await profileService.GetProfilesAsync());
+        //})
+        apiGroup.MapGet(EndpointGenerator.EndpointsStringEmpty, EndpointsHandler.GetAllHandlerAsync)
+            .Produces<List<UserProfileModel>>(StatusCodes.Status200OK)
+            .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
+            .RequireAuthorization(nameof(Permissions.ProfiloRead))
+            .WithOpenApi(opt =>
+            {
+                opt.Summary = "Get all profiles";
+                opt.Description = "Get all profiles";
+
+                opt.Response(StatusCodes.Status200OK).Description = "List of users profiles";
+                opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
+                opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
+
+                return opt;
+            });
+
+        //apiGroup.MapGet(EndpointsApi.EndpointsGetProfile, async ([FromServices] IProfileService profileService,
+        //    [FromRoute] int userId) =>
+        //{
+        //    return TypedResults.Ok(await profileService.GetProfileAsync(userId));
+        //})
+        apiGroup.MapGet(ProfileExtensions.EndpointsGetProfile, EndpointsHandler.GetProfileHandlerAsync)
+        .Produces<UserProfileModel>(StatusCodes.Status200OK)
+        .ProducesDefaultProblem(StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
+        .RequireAuthorization(nameof(Permissions.ProfiloRead))
+        .WithOpenApi(opt =>
+        {
+            opt.Summary = "Get user profile";
+            opt.Description = "Get user profile by username";
+
+            opt.Response(StatusCodes.Status200OK).Description = "User profile retrieved successfully";
+            opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
+            opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
+            return opt;
+        });
+
+        //apiGroup.MapPost(ProfileExtensions.EndpointsChangeEnableProfile, async ([FromServices] IProfileService profileService,
+        //    [FromBody] ChangeEnableProfileModel inputModel) =>
+        //{
+        //    return TypedResults.Ok(await profileService.ChangeEnablementStatusUserProfileAsync(inputModel));
+        //})
+        apiGroup.MapPost(ProfileExtensions.EndpointsChangeEnableProfile, EndpointsHandler.ChangeUserStatusAsync)
+            .Produces<UserProfileModel>(StatusCodes.Status200OK)
+            .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound)
+            .RequireAuthorization(nameof(Permissions.ProfiloRead))
+            .WithOpenApi(opt =>
+            {
+                opt.Summary = "Edit user profile enablement";
+                opt.Description = "Edit user profile enablement";
+
+                opt.Response(StatusCodes.Status200OK).Description = "User profile retrieved successfully";
+                opt.Response(StatusCodes.Status400BadRequest).Description = "Bad request";
+                opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
+                opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
+                return opt;
+            });
+
+        //apiGroup.MapPut(ProfileExtensions.EndpointsEditProfile, async ([FromServices] IProfileService profileService,
+        //    [FromBody] EditUserProfileModel inputModel) =>
+        //{
+        //    return TypedResults.Ok(await profileService.EditProfileAsync(inputModel));
+        //})
+        apiGroup.MapPut(ProfileExtensions.EndpointsEditProfile, EndpointsHandler.EditProfileAsync)
+            .Produces<string>(StatusCodes.Status200OK)
+            .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status404NotFound, StatusCodes.Status422UnprocessableEntity)
+            .RequireAuthorization(nameof(Permissions.ProfiloWrite))
+            .WithValidation<EditUserProfileModel>()
+            .WithOpenApi(opt =>
+            {
+                opt.Summary = "Update user profile";
+                opt.Description = "Update user profile by username";
+
+                opt.Response(StatusCodes.Status200OK).Description = "User profile updated successfully";
+                opt.Response(StatusCodes.Status400BadRequest).Description = "Bad request";
+                opt.Response(StatusCodes.Status401Unauthorized).Description = "Unauthorized";
+                opt.Response(StatusCodes.Status404NotFound).Description = "Not found";
+
+                return opt;
+            });
+
+        return apiGroup;
+    }
+}

--- a/src/MinimalApi.Identity.ProfileManager/Extensions/EndpointsHandler.cs
+++ b/src/MinimalApi.Identity.ProfileManager/Extensions/EndpointsHandler.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MinimalApi.Identity.ProfileManager.Models;
+using MinimalApi.Identity.ProfileManager.Services;
+
+namespace MinimalApi.Identity.ProfileManager.Extensions;
+
+public static class EndpointsHandler
+{
+    public static async Task<IResult> GetAllHandlerAsync([FromServices] IProfileService profileService, HttpContext httpContext)
+        => Results.Ok(await profileService.GetAllProfilesAsync(httpContext.RequestAborted));
+
+    public static async Task<IResult> GetProfileHandlerAsync([FromServices] IProfileService profileService, [FromRoute] int userId, HttpContext httpContext)
+        => Results.Ok(await profileService.GetProfileAsync(userId, httpContext.RequestAborted));
+
+    public static async Task<IResult> EditProfileAsync([FromServices] IProfileService profileService, [FromBody] EditUserProfileModel inputModel, HttpContext httpContext)
+        => Results.Ok(await profileService.EditProfileAsync(inputModel, httpContext.RequestAborted));
+
+    public static async Task<IResult> ChangeUserStatusAsync([FromServices] IProfileService profileService, [FromBody] ChangeEnableProfileModel inputModel, HttpContext httpContext)
+        => Results.Ok(await profileService.ChangeEnablementStatusUserProfileAsync(inputModel, httpContext.RequestAborted));
+}

--- a/src/MinimalApi.Identity.ProfileManager/Mapping/ProfileMapper.cs
+++ b/src/MinimalApi.Identity.ProfileManager/Mapping/ProfileMapper.cs
@@ -1,0 +1,31 @@
+﻿using MinimalApi.Identity.Core.Entities;
+using MinimalApi.Identity.ProfileManager.Models;
+
+namespace MinimalApi.Identity.API.Mapping;
+
+internal static class ProfileMapper
+{
+    internal static UserProfileModel ToEntity(this UserProfile userProfile)
+    {
+        return new UserProfileModel(
+            userProfile.UserId,
+            userProfile.User.Email!,
+            userProfile.FirstName,
+            userProfile.LastName,
+            userProfile.IsEnabled,
+            userProfile.LastDateChangePassword
+        );
+    }
+
+    //public static AuthPolicy ToEntityModel(this PolicyDetailsResponseModel model)
+    //{
+    //    return new AuthPolicy
+    //    {
+    //        PolicyName = model.PolicyName,
+    //        PolicyDescription = model.PolicyDescription,
+    //        PolicyPermissions = model.PolicyPermissions,
+    //        IsDefault = model.IsDefault,
+    //        IsActive = model.IsActive
+    //    };
+    //}
+}

--- a/src/MinimalApi.Identity.ProfileManager/Services/IProfileService.cs
+++ b/src/MinimalApi.Identity.ProfileManager/Services/IProfileService.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Claims;
+using MinimalApi.Identity.Core.Entities;
+using MinimalApi.Identity.ProfileManager.Models;
+
+namespace MinimalApi.Identity.ProfileManager.Services;
+
+public interface IProfileService
+{
+    Task<List<UserProfileModel>> GetAllProfilesAsync(CancellationToken cancellationToken);
+    Task<UserProfileModel> GetProfileAsync(int userId, CancellationToken cancellationToken);
+    Task<string> CreateProfileAsync(CreateUserProfileModel model, CancellationToken cancellationToken);
+    Task<string> EditProfileAsync(EditUserProfileModel model, CancellationToken cancellationToken);
+    Task<List<Claim>> GetClaimUserProfileAsync(ApplicationUser user, CancellationToken cancellationToken);
+    Task<string> ChangeEnablementStatusUserProfileAsync(ChangeEnableProfileModel model, CancellationToken cancellationToken);
+}

--- a/src/MinimalApi.Identity.ProfileManager/Services/ProfileService.cs
+++ b/src/MinimalApi.Identity.ProfileManager/Services/ProfileService.cs
@@ -1,0 +1,113 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using MinimalApi.Identity.Core.Database;
+using MinimalApi.Identity.Core.Entities;
+using MinimalApi.Identity.ProfileManager.DependencyInjection;
+using MinimalApi.Identity.ProfileManager.Models;
+
+namespace MinimalApi.Identity.ProfileManager.Services;
+
+public class ProfileService(MinimalApiAuthDbContext dbContext, UserManager<ApplicationUser> userManager) : IProfileService
+{
+    public async Task<List<UserProfileModel>> GetAllProfilesAsync(CancellationToken cancellationToken)
+        => await ProfileQuery.GetAllProfilesAsync(dbContext, cancellationToken);
+    //{
+    //    var profiles = await dbContext.Set<UserProfile>()
+    //        .AsNoTracking()
+    //        .Select(profile => ProfileMapper.ToEntity(profile))
+    //        .ToListAsync(cancellationToken);
+
+    //    //return profiles.Count == 0 ? throw new NotFoundProfileException(MessagesAPI.ProfilesNotFound) : profiles;
+    //    return profiles.Count == 0 ? throw new NotFoundException(MessagesAPI.ProfilesNotFound) : profiles;
+    //}
+
+    public async Task<UserProfileModel> GetProfileAsync(int userId, CancellationToken cancellationToken)
+        => await ProfileQuery.GetProfileAsync(userId, dbContext, userManager, cancellationToken);
+    //{
+    //    var user = await userManager.FindByIdAsync(userId.ToString())
+    //        //?? throw new NotFoundProfileException(MessagesAPI.ProfileNotFound);
+    //        ?? throw new NotFoundException(MessagesAPI.ProfileNotFound);
+
+    //    var profile = await dbContext.Set<UserProfile>()
+    //        .AsNoTracking()
+    //        .Where(x => x.UserId == user.Id)
+    //        .FirstOrDefaultAsync(cancellationToken)
+    //        //?? throw new NotFoundProfileException(MessagesAPI.ProfileNotFound);
+    //        ?? throw new NotFoundException(MessagesAPI.ProfileNotFound);
+
+    //    return ProfileMapper.ToEntity(profile);
+    //}
+
+    public async Task<string> CreateProfileAsync(CreateUserProfileModel model, CancellationToken cancellationToken)
+        => await ProfileQuery.CreateProfileAsync(model, dbContext, cancellationToken);
+    //{
+    //    var profile = new UserProfile(model.UserId, model.FirstName, model.LastName);
+
+    //    profile.ChangeUserEnabled(true);
+    //    profile.ChangeLastDateChangePassword(DateOnly.FromDateTime(DateTime.Now));
+
+    //    dbContext.Set<UserProfile>().Add(profile);
+    //    var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+    //    return result > 0 ? MessagesAPI.ProfileCreated : MessagesAPI.ProfileNotCreated;
+    //}
+
+    public async Task<string> EditProfileAsync(EditUserProfileModel model, CancellationToken cancellationToken)
+        => await ProfileQuery.EditProfileAsync(model, dbContext, cancellationToken);
+    //{
+    //    var profile = await dbContext.Set<UserProfile>().AsNoTracking()
+    //        .Where(x => x.UserId == model.UserId)
+    //        .FirstOrDefaultAsync(cancellationToken)
+    //        //?? throw new NotFoundProfileException(MessagesAPI.ProfileNotFound);
+    //        ?? throw new NotFoundException(MessagesAPI.ProfileNotFound);
+
+    //    profile.ChangeFirstName(model.FirstName);
+    //    profile.ChangeLastName(model.LastName);
+
+    //    dbContext.Set<UserProfile>().Update(profile);
+    //    var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+    //    return result > 0 ? MessagesAPI.ProfileUpdated : throw new BadRequestException(MessagesAPI.ProfileNotUpdated);
+    //}
+
+    public async Task<List<Claim>> GetClaimUserProfileAsync(ApplicationUser user, CancellationToken cancellationToken)
+        => await ProfileQuery.GetClaimUserProfileAsync(user, dbContext, cancellationToken);
+    //{
+    //    var result = await dbContext.Set<UserProfile>()
+    //        .AsNoTracking()
+    //        .Where(ul => ul.UserId == user.Id)
+    //        .Select(ul => new { ul.FirstName, ul.LastName })
+    //        .FirstOrDefaultAsync(cancellationToken);
+
+    //    if (result == null)
+    //    {
+    //        return [];
+    //    }
+
+    //    return
+    //        [
+    //            new Claim(ClaimTypes.GivenName, result.FirstName ?? string.Empty),
+    //            new Claim(ClaimTypes.Surname, result.LastName ?? string.Empty),
+    //            new Claim(ProfileExtensions.FullName, $"{result.FirstName} {result.LastName}")
+    //        ];
+    //}
+
+    public async Task<string> ChangeEnablementStatusUserProfileAsync(ChangeEnableProfileModel model, CancellationToken cancellationToken)
+        => await ProfileQuery.ChangeEnablementStatusUserProfileAsync(model, dbContext, cancellationToken);
+    //{
+    //    var profile = await dbContext.Set<UserProfile>()
+    //        .AsNoTracking()
+    //        .Where(x => x.UserId == model.UserId)
+    //        .FirstOrDefaultAsync(cancellationToken)
+    //        //?? throw new NotFoundProfileException(MessagesAPI.ProfileNotFound);
+    //        ?? throw new NotFoundException(MessagesAPI.ProfileNotFound);
+
+    //    profile.ChangeUserEnabled(model.IsEnabled);
+
+    //    dbContext.Set<UserProfile>().Update(profile);
+    //    var result = await dbContext.SaveChangesAsync(cancellationToken);
+
+    //    return result > 0 ? model.IsEnabled ? MessagesAPI.ProfileEnabled : MessagesAPI.ProfileDisabled
+    //        : throw new BadRequestException(model.IsEnabled ? MessagesAPI.ProfileNotEnabled : MessagesAPI.ProfileNotDisabled);
+    //}
+}


### PR DESCRIPTION
This pull request introduces the initial implementation for the Profile Manager module, including its service registration, endpoint definitions, query logic, and supporting handlers. Additionally, it updates dependencies and CI workflows to support publishing related modules. The main changes are grouped below:

**Profile Manager Module Implementation**

* Added `ProfileExtensions.cs` to provide service registration and endpoint path constants for the Profile Manager (`ProfileManagerRegistrationService`).
* Implemented `ProfileQuery.cs` with async methods for querying, creating, editing, and enabling/disabling user profiles, as well as retrieving profile claims.
* Added `ProfilesEndpoints.cs` to define and document API endpoints for profile operations using minimal APIs, with OpenAPI integration and authorization.
* Created `EndpointsHandler.cs` to encapsulate endpoint handler logic for profile operations, delegating to the profile service.
* Added `ProfileMapper.cs` for mapping between `UserProfile` entities and `UserProfileModel` DTOs.
* Defined the `IProfileService` interface specifying all required profile-related operations.

**Dependency and Workflow Updates**

* Updated `Directory.Packages.props` to include the new `Identity.Module.ProfileManager` package reference.
* Added new GitHub Actions workflows to publish `Identity.Module.AccountManager` and `Identity.Module.Results` to NuGet, including build, versioning, and release steps. [[1]](diffhunk://#diff-d5fe186ca26893b72fbaa1924889229b67928e4b372badb89bfba892ff61a9b0R1-R54) [[2]](diffhunk://#diff-64813bccbde3a9bb0f8999792a1006a8162890871dc63224562e7c808ec75fb9R1-R54)
* Commented out the `pull_request` trigger in `.github/workflows/linter.yml`, so the linter workflow no longer runs on pull requests for now.