### PR TITLE
Develop

### DIFF
--- a/src/MinimalApi.Identity.Shared/MinIO/MinioS3Sink.cs
+++ b/src/MinimalApi.Identity.Shared/MinIO/MinioS3Sink.cs
@@ -1,0 +1,73 @@
+﻿using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using MinimalApi.Identity.Shared.Options;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+
+namespace MinimalApi.Identity.Shared.MinIO;
+
+public class MinioS3Sink : ILogEventSink
+{
+    private readonly IAmazonS3 s3Client;
+    private readonly JsonFormatter jsonFormatter;
+    private readonly string bucketName;
+    private readonly string logObjectKey;
+
+    public MinioS3Sink(MinioOptions options)
+    {
+        var config = new AmazonS3Config
+        {
+            ServiceURL = options.Endpoint,
+            ForcePathStyle = true
+        };
+
+        s3Client = new AmazonS3Client(options.AccessKey, options.SecretKey, config);
+        bucketName = options.BucketName;
+        logObjectKey = options.LogObjectKey;
+        jsonFormatter = new JsonFormatter();
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        // Serializza logEvent in JSON
+        string logLine;
+        using (var sw = new StringWriter())
+        {
+            jsonFormatter.Format(logEvent, sw);
+            logLine = sw.ToString();
+        }
+
+        logLine += "\n";
+        UploadLogAsync(logLine).Wait();
+    }
+
+    private async Task UploadLogAsync(string logLine)
+    {
+        var existingLogs = "";
+
+        try
+        {
+            var getObjectResponse = await s3Client.GetObjectAsync(bucketName, logObjectKey);
+            using var reader = new StreamReader(getObjectResponse.ResponseStream);
+            existingLogs = reader.ReadToEnd();
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            existingLogs = "";
+        }
+
+        var combinedLogs = existingLogs + logLine;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(combinedLogs));
+
+        var putRequest = new PutObjectRequest
+        {
+            BucketName = bucketName,
+            Key = logObjectKey,
+            InputStream = stream
+        };
+
+        await s3Client.PutObjectAsync(putRequest);
+    }
+}

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.7.4" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.7.6" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.20" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">

--- a/src/MinimalApi.Identity.Shared/Options/MinioOptions.cs
+++ b/src/MinimalApi.Identity.Shared/Options/MinioOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace MinimalApi.Identity.Shared.Options;
+
+public class MinioOptions
+{
+    public string Endpoint { get; set; } = null!; // endpoint del server MinIO: http://127.0.0.1:9000
+    public string AccessKey { get; set; } = null!; // credenziali di accesso
+    public string SecretKey { get; set; } = null!; // credenziali di accesso
+    public string BucketName { get; set; } = null!; // nome del bucket: logs
+    public string LogObjectKey { get; set; } = null!; // prefisso per gli oggetti: serilog-demo.json
+}


### PR DESCRIPTION
This pull request introduces a new Serilog sink for logging to MinIO/S3, adds configuration options for MinIO connectivity, and updates the AWS S3 SDK version. These changes enable the application to serialize log events as JSON and store them in an S3-compatible object store, such as MinIO.

**MinIO S3 Logging Integration:**

* Added a new `MinioS3Sink` class in `MinioS3Sink.cs` to serialize Serilog log events as JSON and append them to an object in an S3-compatible bucket (e.g., MinIO). This includes logic to read existing logs, append new entries, and upload the combined log back to the bucket.

**Configuration:**

* Introduced a new `MinioOptions` class in `MinioOptions.cs` to encapsulate connection and authentication details for MinIO/S3, such as endpoint, access key, secret key, bucket name, and log object key.

**Dependency Updates:**

* Updated the `AWSSDK.S3` NuGet package version from `4.0.7.4` to `4.0.7.6` in the project file to ensure compatibility and access to the latest features and fixes.