### PR TITLE
Clean up comments and streamline dynamic policy handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 ## General
 
 - Make only high confidence suggestions when reviewing code changes.
-- Always use the latest version C#, currently C# 12 features.
+- Always use the latest version C#, currently C# 13 features.
 - Write code that is clean, maintainable, and easy to understand.
 - Only add comments rarely to explain why a non-intuitive solution was used. The code should be self-explanatory otherwise.
 - Don't add the UTF-8 BOM to files unless they have non-ASCII characters.

--- a/src/MinimalApi.Identity.API/Extensions/DatabasesExtensions.cs
+++ b/src/MinimalApi.Identity.API/Extensions/DatabasesExtensions.cs
@@ -98,10 +98,7 @@ public static class DatabasesExtensions
             method?.Invoke(null, [optionsBuilder]);
         }
         catch
-        {
-            // Swallow: provider package may not be referenced / available at runtime.
-            // If you want diagnostics, log here using your logger.
-        }
+        { }
     }
 
     private static IEnumerable<Type> GetTypesSafe(Assembly assembly)

--- a/src/MinimalApi.Identity.API/Extensions/RegisterServicesExtensions.cs
+++ b/src/MinimalApi.Identity.API/Extensions/RegisterServicesExtensions.cs
@@ -150,10 +150,7 @@ public static class RegisterServicesExtensions
 
         services.AddDbContext<TDbContext>((serviceProvider, options) =>
         {
-            // Apply the base options configured by optionsAction
             optionsAction(options);
-
-            // Resolve EF Core interceptors registered in DI and add them dynamically.
             var interceptors = serviceProvider.GetServices<IInterceptor>().ToArray();
 
             if (interceptors.Length != 0)
@@ -161,10 +158,8 @@ public static class RegisterServicesExtensions
                 options.AddInterceptors(interceptors);
             }
 
-            // Helpful for debugging — optional in production
             options.EnableSensitiveDataLogging();
             options.LogTo(Console.WriteLine, LogLevel.Information);
-
             options.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
         });
 
@@ -185,8 +180,6 @@ public static class RegisterServicesExtensions
         }
 
         var pendingMigrations = await dbContext.Database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
-
-        // Fast-path when the returned collection exposes Count to avoid enumerator allocation.
         bool hasPending;
 
         if (pendingMigrations is ICollection<string> coll)

--- a/src/MinimalApi.Identity.API/Extensions/SwaggerExtensions.cs
+++ b/src/MinimalApi.Identity.API/Extensions/SwaggerExtensions.cs
@@ -33,7 +33,6 @@ public static class SwaggerExtensions
         {
             In = ParameterLocation.Header,
             Name = "Authorization",
-            //BearerFormat = "JWT",
             Description = "JWT Authorization header using the Bearer scheme.",
             Type = SecuritySchemeType.ApiKey,
             Reference = new OpenApiReference

--- a/src/MinimalApi.Identity.PolicyManager/Provider/DynamicAuthorizationPolicyProvider.cs
+++ b/src/MinimalApi.Identity.PolicyManager/Provider/DynamicAuthorizationPolicyProvider.cs
@@ -14,8 +14,6 @@ public class DynamicAuthorizationPolicyProvider(IServiceProvider serviceProvider
     {
         using var scope = serviceProvider.CreateScope();
         var policyService = scope.ServiceProvider.GetRequiredService<IAuthPolicyService>();
-
-        // You can pass a real cancellation token if needed
         var policies = await policyService.GetAllPoliciesAsync(CancellationToken.None);
         var policyModel = policies.FirstOrDefault(policy => policy.PolicyName == policyName);
 
@@ -27,7 +25,6 @@ public class DynamicAuthorizationPolicyProvider(IServiceProvider serviceProvider
             return policy;
         }
 
-        // Fallback to static policies
         return authorizationOptions.GetPolicy(policyName);
     }
 

--- a/src/MinimalApi.Identity.Shared/DependencyInjection/SharedExtensions.cs
+++ b/src/MinimalApi.Identity.Shared/DependencyInjection/SharedExtensions.cs
@@ -14,7 +14,6 @@ public static class SharedExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // Register interceptors as IInterceptor so GetServices<IInterceptor>() returns them
         // Documentation: https://dev.to/madusanka_bandara/mastering-database-interceptors-in-net-core-web-api-beginner-to-hero-18g8
         services.AddScoped<IInterceptor, LoggingInterceptor>();
         services.AddScoped<IInterceptor, PerformanceInterceptor>();

--- a/src/MinimalApi.Identity.Shared/Interceptor/SecurityInterceptor.cs
+++ b/src/MinimalApi.Identity.Shared/Interceptor/SecurityInterceptor.cs
@@ -60,7 +60,6 @@ public class SecurityInterceptor(ILogger<SecurityInterceptor> logger) : DbComman
                 continue;
             }
 
-            // no more leading comments/whitespace
             break;
         }
 
@@ -116,7 +115,6 @@ public class SecurityInterceptor(ILogger<SecurityInterceptor> logger) : DbComman
 
         if (idx == -1)
         {
-            // unterminated block comment: treat as end of text
             i = len;
             return true;
         }
@@ -134,7 +132,6 @@ public class SecurityInterceptor(ILogger<SecurityInterceptor> logger) : DbComman
             return false;
         }
 
-        // Use string.IndexOf with start index to avoid allocation of substring.
         return text.IndexOf("WHERE", startIndex, StringComparison.OrdinalIgnoreCase) == -1;
     }
 }


### PR DESCRIPTION
This pull request primarily focuses on code cleanup and modernization across several files. The main changes include updating documentation to reference C# 13, removing redundant or explanatory comments to streamline the code, and making minor improvements to code clarity and maintainability.

**Documentation Update:**
- Updated `.github/copilot-instructions.md` to reference C# 13 as the latest version, ensuring guidance reflects the most current language features.

**Code Cleanup and Comment Removal:**
- Removed explanatory and redundant comments throughout the codebase to improve readability and maintainability, including in `RegisterServicesExtensions.cs`, `DatabasesExtensions.cs`, `SwaggerExtensions.cs`, `DynamicAuthorizationPolicyProvider.cs`, `SharedExtensions.cs`, and `SecurityInterceptor.cs`. [[1]](diffhunk://#diff-d6d504ced3d487019f4a117bd398ea137695f973bf42d9adedfca36cf6bba0d6L153-L167) [[2]](diffhunk://#diff-d6d504ced3d487019f4a117bd398ea137695f973bf42d9adedfca36cf6bba0d6L188-L189) [[3]](diffhunk://#diff-f78305e903ccdf3d3898dcd7fb97ab7b58bac2d83a4b6183f080002629331e23L101-R101) [[4]](diffhunk://#diff-ee9da88f3527ccb732dcbe59855c883898f91904f673261bf82e138d37e517f3L36) [[5]](diffhunk://#diff-e305961cce3c786b9ed9c2eaf8a5e61bd9449237a1c4a2cb0126cbc83a236cf8L17-L18) [[6]](diffhunk://#diff-e305961cce3c786b9ed9c2eaf8a5e61bd9449237a1c4a2cb0126cbc83a236cf8L30) [[7]](diffhunk://#diff-b735baf099347ef931ada5b0bf6f7ea97584ee4e9c77baccb5128fe9dced06d8L17) [[8]](diffhunk://#diff-6f7f33c2c864864b0017dd3ff36ac6bbc753f573abcfa36bf764d55d65b045a1L63) [[9]](diffhunk://#diff-6f7f33c2c864864b0017dd3ff36ac6bbc753f573abcfa36bf764d55d65b045a1L119) [[10]](diffhunk://#diff-6f7f33c2c864864b0017dd3ff36ac6bbc753f573abcfa36bf764d55d65b045a1L137)

**Minor Code Improvements:**
- Slightly refactored exception handling in `TryApplyExceptionProcessor` to use a more concise empty catch block.
- Maintained or clarified logic in methods by removing unnecessary inline comments, making the code more self-explanatory. [[1]](diffhunk://#diff-d6d504ced3d487019f4a117bd398ea137695f973bf42d9adedfca36cf6bba0d6L153-L167) [[2]](diffhunk://#diff-6f7f33c2c864864b0017dd3ff36ac6bbc753f573abcfa36bf764d55d65b045a1L137)