### PR TITLE
Upgrade Identity.Module NuGet packages to latest versions

### DIFF
--- a/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
+++ b/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
@@ -25,7 +25,7 @@
     
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Identity.Module.Shared" Version="2.5.117" />
+        <PackageReference Include="Identity.Module.Shared" Version="2.5.119" />
         <PackageReference Include="MailKit" Version="4.16.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.15" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />

--- a/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
+++ b/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.225" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
+++ b/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.225" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.225" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
+++ b/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.225" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
+++ b/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.225" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request updates package dependencies across several projects to ensure compatibility with the latest versions and to incorporate recent fixes and features.

**Dependency updates:**

* Updated `Identity.Module.Core` package to version `2.5.226` in the following projects:
  - `MinimalApi.Identity.LicenseManager.csproj`
  - `MinimalApi.Identity.ModuleManager.csproj`
  - `MinimalApi.Identity.PolicyManager.csproj`
  - `MinimalApi.Identity.ProfileManager.csproj`
  - `MinimalApi.Identity.RolesManager.csproj`

* Updated `Identity.Module.Shared` package to version `2.5.119` in `MinimalApi.Identity.Core.csproj`