### PR TITLE
Update README and disable scheduled SonarQube workflow trigger

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,7 +9,7 @@ on:
 
 #  schedule:
 #    - cron: "0 */12 * * *"
-    
+
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,8 +7,8 @@ on:
 #    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
-  schedule:
-    - cron: "0 */12 * * *"
+#  schedule:
+#    - cron: "0 */12 * * *"
     
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -119,20 +119,18 @@ A default administrator account is created automatically with the following conf
 
 In this solution:
 
-- [X] Migrate solution to .NET 9
+- [ ] 
 
 In the .NET 10 solution (in a dedicated [repository](https://github.com/IdentitySystem))
 
 - [ ] Migrate solution to .NET 10 (⌛ in progress)
-- [X] Change the entity ID type from INT to GUID
-- [X] Make the ID entity type dynamic, so that it can accept both INT and GUID at runtime
-- [X] Migrate SwaggerSettings configuration to database
-- [X] Migrate SmtpOptions configuration to database
-- [X] Replacing exceptions with implementation of operation results
 - [ ] Replacing the hosted service email sender using Coravel jobs
-- [ ] Align endpoints with the updated version of ASP.NET Core Identity (including endpoints for two-factor authentication and management, downloading and deleting personal data)
 - [ ] Add support for multi tenancy
-- [ ] Add authentication support from third-party providers (e.g. Auth0, KeyCloak, GitHub, Azure)
+- [ ] Align endpoints with the updated version of ASP.NET Core Identity (including endpoints for two-factor authentication and management, downloading and deleting personal data)
+- [ ] Add authentication support from third-party providers Auth0
+- [ ] Add authentication support from third-party providers KeyCloak
+- [ ] Add authentication support from third-party providers GitHub
+- [ ] Add authentication support from third-party providers Azure
 - [ ] Code Review and Refactoring
 - [ ] Update documentation
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ In this solution:
 
 - [ ] 
 
-In the .NET 10 solution (in a dedicated [repository](https://github.com/IdentitySystem))
+In the .NET 10 solution (in a dedicated temporarily private repository)
 
 - [ ] Migrate solution to .NET 10 (⌛ in progress)
 - [ ] Replacing the hosted service email sender using Coravel jobs

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ In this solution:
 
 - [ ] 
 
-In the .NET 10 solution (in a dedicated temporarily private repository)
+In the .NET 10 solution (in a dedicated, temporarily private repository):
 
 - [ ] Migrate solution to .NET 10 (⌛ in progress)
 - [ ] Replacing the hosted service email sender using Coravel jobs


### PR DESCRIPTION
This pull request includes minor updates to the workflow configuration and documentation. The scheduled SonarQube workflow has been commented out, and the `README.md` has been updated to reflect the current migration status and clarify plans for third-party authentication providers.

**Workflow configuration:**

* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792L10-R11): Commented out the scheduled SonarQube workflow, disabling automatic runs on a schedule.

**Documentation updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R133): Updated migration checklist to .NET 10, clarified repository status, and split third-party authentication providers into individual items for Auth0, KeyCloak, GitHub, and Azure. Also removed completed items related to .NET 9 migration and configuration changes.