### PR TITLE
Upgrade Identity.Module.Core to v2.5.227 and AWSSDK.S3 to v4.0.23.4

### DIFF
--- a/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
+++ b/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
+++ b/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
+++ b/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.226" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.23" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.23.4" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.15" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">


### PR DESCRIPTION
This pull request updates package dependencies across several projects to ensure compatibility with the latest versions and to incorporate recent improvements and bug fixes.

Dependency updates:

* Updated the `Identity.Module.Core` package reference from version `2.5.226` to `2.5.227` in the following projects: `MinimalApi.Identity.ModuleManager`, `MinimalApi.Identity.PolicyManager`, `MinimalApi.Identity.ProfileManager`, and `MinimalApi.Identity.RolesManager`. [[1]](diffhunk://#diff-a51dfc24a16ac19c9a9b5cf19c93a0c4d0cd69d9549dc544dfd18db238e469d7L27-R27) [[2]](diffhunk://#diff-1b0c19822b5e514e2f44a2a3b1f89d1bf4af016bcabc938ec7996626972efa99L27-R27) [[3]](diffhunk://#diff-4f98bb15fa235b3fd96339c76ea6a47de92d92400798e590bc3a0b54fe917eacL27-R27) [[4]](diffhunk://#diff-1fe98078ff1c49d47c8ef23cba91f1362abe643a3399d404158f87df4115e239L27-R27)
* Updated the `AWSSDK.S3` package reference from version `4.0.23` to `4.0.23.4` in `MinimalApi.Identity.Shared`.