### PR TITLE
Update NuGet package versions for Identity and EF Core

### DIFF
--- a/IdentityManager.API/IdentityManager.API.csproj
+++ b/IdentityManager.API/IdentityManager.API.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.API" Version="2.5.450" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
+        <PackageReference Include="Identity.Module.API" Version="2.5.452" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -30,21 +30,21 @@
     <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.Sqlite" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
-    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.120" />
-    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.92" />
-    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.35" />
+    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.122" />
+    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.94" />
+    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.37" />
     <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
-    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.95" />
-    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.99" />
-    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.38" />
-    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.117" />
-    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.108" />
-    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.66" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.15" />
+    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.97" />
+    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.101" />
+    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.39" />
+    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.118" />
+    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.109" />
+    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.67" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
 </ItemGroup>

--- a/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
+++ b/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
@@ -8,8 +8,8 @@
     
     <ItemGroup>
         <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -32,9 +32,9 @@
     
     <ItemGroup>
       <PackageReference Include="AWSSDK.S3" Version="4.0.23.4" />
-      <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.15" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
+      <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.16" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>


### PR DESCRIPTION
This pull request updates several project files to bump the versions of various NuGet package dependencies, focusing mainly on the Microsoft Entity Framework Core libraries and several internal Identity modules. These updates help ensure compatibility with the latest features and bug fixes.

Dependency version updates:

**Microsoft Entity Framework Core and related libraries:**
* Upgraded `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Sqlite`, `Microsoft.AspNetCore.Identity.EntityFrameworkCore`, `Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore`, and `Microsoft.AspNetCore.Authentication.JwtBearer` from version 9.0.15 to 9.0.16 across multiple projects. [[1]](diffhunk://#diff-474a67afa2cbbbca9101a7effc568d81c2b8b7839463d4ed2145c9f00dd36af6L11-R12) [[2]](diffhunk://#diff-5de172071dc83e61a1f7d4c44b08d6d91bc8a9112093d68cc0505c83084c4fb3L33-R47) [[3]](diffhunk://#diff-4a0d32b9caecbfd5d7dd2478ddebbd7cfdccb952cf7dfd4840d7747474ec6d3cL11-R12) [[4]](diffhunk://#diff-217912b0704ab7ec60dd58864cb1580d8c0bb61b7564d1f0aa503744d255cdc6L35-R37)

**Internal Identity modules:**
* Updated various internal `Identity.Module.*` package references to newer patch versions in `MinimalApi.Identity.API.csproj`, including `AccountManager`, `AuthManager`, `ClaimsManager`, `EmailManager`, `LicenseManager`, `ModuleManager`, `PolicyManager`, `ProfileManager`, and `RolesManager`.
* Updated `Identity.Module.API` from version 2.5.450 to 2.5.452.