### PR TITLE
Upgrade EmailManager and related NuGet packages to latest versions

### DIFF
--- a/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
+++ b/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
@@ -25,7 +25,7 @@
 
     <ItemGroup>
         <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
-        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.95" />
+        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.97" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
+++ b/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
@@ -25,11 +25,11 @@
     
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Identity.Module.Shared" Version="2.5.119" />
-        <PackageReference Include="MailKit" Version="4.16.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.15" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
+        <PackageReference Include="Identity.Module.Shared" Version="2.5.120" />
+        <PackageReference Include="MailKit" Version="4.17.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies to newer versions in the `MinimalApi.Identity.AccountManager` and `MinimalApi.Identity.Core` projects. These updates help ensure compatibility, security, and access to the latest features and bug fixes.

Dependency updates:

**Account Manager project:**
- Upgraded `Identity.Module.EmailManager` from version 2.5.95 to 2.5.97.

**Core project:**
- Upgraded `Identity.Module.Shared` from 2.5.119 to 2.5.120.
- Upgraded `MailKit` from 4.16.0 to 4.17.0.
- Upgraded `Microsoft.AspNetCore.Identity.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, and `Microsoft.EntityFrameworkCore.Tools` from 9.0.15 to 9.0.16.