### PR TITLE
Upgrade Identity.Module.Core to version 2.5.228 across projects

### DIFF
--- a/src/MinimalApi.Identity.ClaimsManager/MinimalApi.Identity.ClaimsManager.csproj
+++ b/src/MinimalApi.Identity.ClaimsManager/MinimalApi.Identity.ClaimsManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
+++ b/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
     </ItemGroup>    
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
+++ b/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
+++ b/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
             <PrivateAssets>all</PrivateAssets>

--- a/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
+++ b/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.227" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This pull request updates the `Identity.Module.Core` package version from `2.5.227` to `2.5.228` across multiple projects to ensure consistency and access to the latest features or fixes.

Dependency updates:

* Bumped `Identity.Module.Core` package version to `2.5.228` in the following project files:
  - `MinimalApi.Identity.ClaimsManager.csproj`
  - `MinimalApi.Identity.EmailManager.csproj`
  - `MinimalApi.Identity.LicenseManager.csproj`
  - `MinimalApi.Identity.Migrations.SQLServer.csproj`
  - `MinimalApi.Identity.ModuleManager.csproj`
  - `MinimalApi.Identity.PolicyManager.csproj`