### PR TITLE
Upgrade NuGet packages to latest versions for Identity modules

### DIFF
--- a/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
+++ b/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
@@ -25,7 +25,7 @@
     
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Identity.Module.Shared" Version="2.5.121" />
+        <PackageReference Include="Identity.Module.Shared" Version="2.5.122" />
         <PackageReference Include="MailKit" Version="4.17.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />

--- a/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
+++ b/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>    
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
+++ b/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
+++ b/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
             <PrivateAssets>all</PrivateAssets>

--- a/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
+++ b/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.23.5" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.23.6" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.16" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">


### PR DESCRIPTION
This pull request updates several package dependencies across multiple projects to ensure that the latest versions are used. The primary focus is on upgrading the `Identity.Module.Core`, `Identity.Module.Shared`, and `AWSSDK.S3` packages. No functional code changes are included.

Dependency updates:

**Identity module updates:**
* Upgraded `Identity.Module.Core` from version `2.5.228` to `2.5.229` in the following projects: `MinimalApi.Identity.EmailManager`, `MinimalApi.Identity.LicenseManager`, `MinimalApi.Identity.Migrations.SQLServer`, `MinimalApi.Identity.ModuleManager`, and `MinimalApi.Identity.PolicyManager`. [[1]](diffhunk://#diff-7576a35f96e490aeeed71389faf0c2ec94423e93150bba8458df557a97765692L27-R27) [[2]](diffhunk://#diff-205d1a06450607974a8086240a88e2a98784a0f4507315d262b0fef61ca49af5L27-R27) [[3]](diffhunk://#diff-4a0d32b9caecbfd5d7dd2478ddebbd7cfdccb952cf7dfd4840d7747474ec6d3cL10-R10) [[4]](diffhunk://#diff-a51dfc24a16ac19c9a9b5cf19c93a0c4d0cd69d9549dc544dfd18db238e469d7L27-R27) [[5]](diffhunk://#diff-1b0c19822b5e514e2f44a2a3b1f89d1bf4af016bcabc938ec7996626972efa99L27-R27)
* Upgraded `Identity.Module.Shared` from version `2.5.121` to `2.5.122` in `MinimalApi.Identity.Core`.

**AWS SDK update:**
* Upgraded `AWSSDK.S3` from version `4.0.23.5` to `4.0.23.6` in `MinimalApi.Identity.Shared`.