### PR TITLE
Upgrade Identity.Module packages to latest versions and patches

### DIFF
--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -33,11 +33,11 @@
     <PackageReference Include="Identity.Module.AccountManager" Version="2.5.124" />
     <PackageReference Include="Identity.Module.AuthManager" Version="2.5.95" />
     <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.38" />
-    <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
-    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.98" />
-    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.102" />
-    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.40" />
-    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.119" />
+    <PackageReference Include="Identity.Module.Core" Version="2.5.230" />
+    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.99" />
+    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.103" />
+    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.41" />
+    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.120" />
     <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.111" />
     <PackageReference Include="Identity.Module.RolesManager" Version="2.5.69" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />

--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -30,16 +30,16 @@
     <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.Sqlite" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
-    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.123" />
-    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.94" />
-    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.37" />
-    <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
-    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.97" />
-    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.101" />
-    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.39" />
-    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.118" />
-    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.109" />
-    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.67" />
+    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.124" />
+    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.95" />
+    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.38" />
+    <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
+    <PackageReference Include="Identity.Module.EmailManager" Version="2.5.98" />
+    <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.102" />
+    <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.40" />
+    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.119" />
+    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.111" />
+    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.69" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.16" />

--- a/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
+++ b/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
@@ -24,8 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
-        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.98" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.230" />
+        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.99" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
+++ b/src/MinimalApi.Identity.AccountManager/MinimalApi.Identity.AccountManager.csproj
@@ -24,8 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
-        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.97" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
+        <PackageReference Include="Identity.Module.EmailManager" Version="2.5.98" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.AuthManager/MinimalApi.Identity.AuthManager.csproj
+++ b/src/MinimalApi.Identity.AuthManager/MinimalApi.Identity.AuthManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.ClaimsManager/MinimalApi.Identity.ClaimsManager.csproj
+++ b/src/MinimalApi.Identity.ClaimsManager/MinimalApi.Identity.ClaimsManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.228" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.229" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request updates several internal package dependencies across multiple projects to their latest patch versions. These changes help ensure that all modules are using the most recent bug fixes and improvements from the `Identity.Module` packages.

Dependency updates:

**Core and Shared Modules:**
* Updated `Identity.Module.Core` to version `2.5.230` in `MinimalApi.Identity.API` and `MinimalApi.Identity.AccountManager`, and to `2.5.229` in `MinimalApi.Identity.AuthManager` and `MinimalApi.Identity.ClaimsManager`. [[1]](diffhunk://#diff-5de172071dc83e61a1f7d4c44b08d6d91bc8a9112093d68cc0505c83084c4fb3L33-R42) [[2]](diffhunk://#diff-2ce4bd16ada07912f004b7de0b81a1afdfc634e029cf9675fb811f475a7a60c4L27-R28) [[3]](diffhunk://#diff-6917862d6ad971b3c8b8a581d4d0e323218daa3d8e87b237ec656214ccfee11dL27-R27) [[4]](diffhunk://#diff-06579d29474387749a8cf70c4f7fb0c48d7cc593e8e2889cf13f5d6ddb97c1f5L27-R27)

**Feature-Specific Modules:**
* Updated the following packages to their latest patch versions in `MinimalApi.Identity.API`:
  - `Identity.Module.AccountManager` to `2.5.124`
  - `Identity.Module.AuthManager` to `2.5.95`
  - `Identity.Module.ClaimsManager` to `2.5.38`
  - `Identity.Module.EmailManager` to `2.5.99`
  - `Identity.Module.LicenseManager` to `2.5.103`
  - `Identity.Module.ModuleManager` to `2.5.41`
  - `Identity.Module.PolicyManager` to `2.5.120`
  - `Identity.Module.ProfileManager` to `2.5.111`
  - `Identity.Module.RolesManager` to `2.5.69`

* Updated `Identity.Module.EmailManager` to `2.5.99` in `MinimalApi.Identity.AccountManager`.