### PR TITLE
Update Identity module and Nerdbank.GitVersioning package versions

### DIFF
--- a/IdentityManager.API/IdentityManager.API.csproj
+++ b/IdentityManager.API/IdentityManager.API.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.API" Version="2.5.460" />
+        <PackageReference Include="Identity.Module.API" Version="2.5.462" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.Sqlite" Version="8.1.3" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
-    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.128" />
-    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.99" />
-    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.42" />
+    <PackageReference Include="Identity.Module.AccountManager" Version="2.5.130" />
+    <PackageReference Include="Identity.Module.AuthManager" Version="2.5.100" />
+    <PackageReference Include="Identity.Module.ClaimsManager" Version="2.5.43" />
     <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     <PackageReference Include="Identity.Module.EmailManager" Version="2.5.102" />
     <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.106" />

--- a/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
+++ b/src/MinimalApi.Identity.EmailManager/MinimalApi.Identity.EmailManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>    
     
     <ItemGroup>
@@ -32,6 +32,10 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>    
+    
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>    
     
 </Project>

--- a/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
+++ b/src/MinimalApi.Identity.LicenseManager/MinimalApi.Identity.LicenseManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>
     
     <ItemGroup>
@@ -32,6 +32,10 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
     
 </Project>

--- a/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
+++ b/src/MinimalApi.Identity.Migrations.SQLServer/MinimalApi.Identity.Migrations.SQLServer.csproj
@@ -7,11 +7,15 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.17" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
 </Project>

--- a/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
+++ b/src/MinimalApi.Identity.ModuleManager/MinimalApi.Identity.ModuleManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,5 +32,9 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
 </Project>

--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>
     
     <ItemGroup>
@@ -32,6 +32,10 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
     
 </Project>

--- a/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
+++ b/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,6 +32,10 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
 
 </Project>

--- a/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
+++ b/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.231" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,6 +32,10 @@
             <Pack>True</Pack>
             <PackagePath></PackagePath>
         </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
 
 </Project>

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.25.2" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.25.3" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">
@@ -44,6 +44,10 @@
       <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
       <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.85" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates several project dependencies to their latest versions and introduces the `Nerdbank.GitVersioning` package to multiple projects for improved version management. The most significant changes are grouped below:

**Dependency updates:**

* Updated `Identity.Module.Core` to version `2.5.233` across all relevant projects to ensure consistency and access to the latest features and fixes. [[1]](diffhunk://#diff-7576a35f96e490aeeed71389faf0c2ec94423e93150bba8458df557a97765692L27-R27) [[2]](diffhunk://#diff-205d1a06450607974a8086240a88e2a98784a0f4507315d262b0fef61ca49af5L27-R27) [[3]](diffhunk://#diff-a51dfc24a16ac19c9a9b5cf19c93a0c4d0cd69d9549dc544dfd18db238e469d7L27-R27) [[4]](diffhunk://#diff-1b0c19822b5e514e2f44a2a3b1f89d1bf4af016bcabc938ec7996626972efa99L27-R27) [[5]](diffhunk://#diff-4f98bb15fa235b3fd96339c76ea6a47de92d92400798e590bc3a0b54fe917eacL27-R27) [[6]](diffhunk://#diff-1fe98078ff1c49d47c8ef23cba91f1362abe643a3399d404158f87df4115e239L27-R27) [[7]](diffhunk://#diff-4a0d32b9caecbfd5d7dd2478ddebbd7cfdccb952cf7dfd4840d7747474ec6d3cL10-R20)
* Updated other Identity module dependencies to their latest patch versions in `MinimalApi.Identity.API.csproj` and `MinimalApi.Identity.API.csproj` (e.g., `Identity.Module.API`, `Identity.Module.AccountManager`, `Identity.Module.AuthManager`, `Identity.Module.ClaimsManager`). [[1]](diffhunk://#diff-474a67afa2cbbbca9101a7effc568d81c2b8b7839463d4ed2145c9f00dd36af6L11-R11) [[2]](diffhunk://#diff-5de172071dc83e61a1f7d4c44b08d6d91bc8a9112093d68cc0505c83084c4fb3L33-R35)
* Updated `AWSSDK.S3` to version `4.0.25.3` in `MinimalApi.Identity.Shared.csproj`.

**Versioning improvements:**

* Added `Nerdbank.GitVersioning` version `3.10.85` to most projects to standardize and automate versioning across the solution. [[1]](diffhunk://#diff-7576a35f96e490aeeed71389faf0c2ec94423e93150bba8458df557a97765692R37-R40) [[2]](diffhunk://#diff-205d1a06450607974a8086240a88e2a98784a0f4507315d262b0fef61ca49af5R37-R40) [[3]](diffhunk://#diff-a51dfc24a16ac19c9a9b5cf19c93a0c4d0cd69d9549dc544dfd18db238e469d7R36-R39) [[4]](diffhunk://#diff-1b0c19822b5e514e2f44a2a3b1f89d1bf4af016bcabc938ec7996626972efa99R37-R40) [[5]](diffhunk://#diff-4f98bb15fa235b3fd96339c76ea6a47de92d92400798e590bc3a0b54fe917eacR37-R40) [[6]](diffhunk://#diff-1fe98078ff1c49d47c8ef23cba91f1362abe643a3399d404158f87df4115e239R37-R40) [[7]](diffhunk://#diff-4a0d32b9caecbfd5d7dd2478ddebbd7cfdccb952cf7dfd4840d7747474ec6d3cL10-R20) [[8]](diffhunk://#diff-217912b0704ab7ec60dd58864cb1580d8c0bb61b7564d1f0aa503744d255cdc6R49-R52)