### PR TITLE
Upgrade Identity.Module.Core to version 2.5.234 across projects

### DIFF
--- a/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
+++ b/src/MinimalApi.Identity.PolicyManager/MinimalApi.Identity.PolicyManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.234" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
+++ b/src/MinimalApi.Identity.ProfileManager/MinimalApi.Identity.ProfileManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.234" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
+++ b/src/MinimalApi.Identity.RolesManager/MinimalApi.Identity.RolesManager.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.Core" Version="2.5.233" />
+        <PackageReference Include="Identity.Module.Core" Version="2.5.234" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request updates the `Identity.Module.Core` package dependency to version 2.5.234 across three different projects. This ensures all related components use the latest version of the shared identity module.

Dependency updates:

* Updated `Identity.Module.Core` package reference from version 2.5.233 to 2.5.234 in the following project files:
  - `MinimalApi.Identity.PolicyManager.csproj`
  - `MinimalApi.Identity.ProfileManager.csproj`
  - `MinimalApi.Identity.RolesManager.csproj`