### PR TITLE
Disable SonarQube workflow push trigger

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,8 +1,8 @@
 name: SonarQube
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
 #  pull_request:
 #    types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
Commented out the push trigger and branches configuration in sonarqube.yml, preventing the workflow from running automatically on pushes to main. The workflow can now only be triggered manually via workflow_dispatch.