### PR TITLE
Update Identity module and AWSSDK.S3 package versions

### DIFF
--- a/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
+++ b/src/MinimalApi.Identity.API/MinimalApi.Identity.API.csproj
@@ -37,9 +37,9 @@
     <PackageReference Include="Identity.Module.EmailManager" Version="2.5.103" />
     <PackageReference Include="Identity.Module.LicenseManager" Version="2.5.107" />
     <PackageReference Include="Identity.Module.ModuleManager" Version="2.5.44" />
-    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.123" />
-    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.114" />
-    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.72" />
+    <PackageReference Include="Identity.Module.PolicyManager" Version="2.5.124" />
+    <PackageReference Include="Identity.Module.ProfileManager" Version="2.5.115" />
+    <PackageReference Include="Identity.Module.RolesManager" Version="2.5.73" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17" />

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.25.3" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.100" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">


### PR DESCRIPTION
This pull request updates several package dependencies to newer versions in both the `MinimalApi.Identity.API` and `MinimalApi.Identity.Shared` projects. These updates include minor version bumps for internal Identity modules and a significant update for the AWS S3 SDK.

Dependency updates:

* Updated `Identity.Module.PolicyManager` to version 2.5.124, `Identity.Module.ProfileManager` to 2.5.115, and `Identity.Module.RolesManager` to 2.5.73 in `MinimalApi.Identity.API.csproj`.
* Updated `AWSSDK.S3` to version 4.0.100 in `MinimalApi.Identity.Shared.csproj`.