### PR TITLE
Upgrade NuGet packages for Identity and AWS SDK

### DIFF
--- a/IdentityManager.API/IdentityManager.API.csproj
+++ b/IdentityManager.API/IdentityManager.API.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Identity.Module.API" Version="2.5.463" />
+        <PackageReference Include="Identity.Module.API" Version="2.5.465" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
+++ b/src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj
@@ -25,7 +25,7 @@
     
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Identity.Module.Shared" Version="2.5.129" />
+        <PackageReference Include="Identity.Module.Shared" Version="2.5.130" />
         <PackageReference Include="MailKit" Version="4.17.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.17" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.17" />

--- a/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
+++ b/src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="4.0.100" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.100.2" />
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.17">


### PR DESCRIPTION
This pull request updates several NuGet package dependencies across multiple projects to ensure compatibility and incorporate the latest improvements and bug fixes. The most important changes are grouped below by project.

**Dependency updates:**

* [`IdentityManager.API/IdentityManager.API.csproj`](diffhunk://#diff-474a67afa2cbbbca9101a7effc568d81c2b8b7839463d4ed2145c9f00dd36af6L11-R11): Upgraded the `Identity.Module.API` package from version `2.5.463` to `2.5.465`.
* [`src/MinimalApi.Identity.Core/MinimalApi.Identity.Core.csproj`](diffhunk://#diff-1536f7d684144ffb0abcc01c6e03c303c6f3fa463acc004c4d64c6600dbd855bL28-R28): Upgraded the `Identity.Module.Shared` package from version `2.5.129` to `2.5.130`.
* [`src/MinimalApi.Identity.Shared/MinimalApi.Identity.Shared.csproj`](diffhunk://#diff-217912b0704ab7ec60dd58864cb1580d8c0bb61b7564d1f0aa503744d255cdc6L34-R34): Upgraded the `AWSSDK.S3` package from version `4.0.100` to `4.0.100.2`.